### PR TITLE
Alt attributes for plugin and theme directory linked images

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
+++ b/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-template.php
@@ -397,9 +397,9 @@ class Template {
 			case 'html':
 
 				if ( $icon_2x && $icon_2x !== $icon ) {
-					return "<img class='plugin-icon' srcset='{$icon}, {$icon_2x} 2x' src='{$icon_2x}'>";
+					return "<img class='plugin-icon' srcset='{$icon}, {$icon_2x} 2x' src='{$icon_2x}' alt=''>";
 				} else {
-					return "<img class='plugin-icon' src='{$icon}'>";
+					return "<img class='plugin-icon' src='{$icon}' alt=''>";
 				}
 				break;
 

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/embed-plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/embed-plugin.php
@@ -136,7 +136,7 @@ if ( ! headers_sent() ) {
 				<?php
 					$plugin_icon = Template::get_plugin_icon( $post, 'html' );
 					$plugin_icon = str_replace( $plugin_icon, "class='plugin-icon'", "class='wp-embed-featured-image rectangular plugin-icon'" );
-					echo $plugin_icon;
+					echo $plugin_icon; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
 				<?php the_title(); ?>
 			</a>

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/embed-plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/embed-plugin.php
@@ -43,10 +43,12 @@ if ( ! headers_sent() ) {
 			margin-left: 20px;
 			margin-right: auto;
 		}
+		.wp-embed-featured-image.plugin-icon,
 		.wp-embed-featured-image .plugin-icon {
 			background-size: 100%;
 			height: 60px;
 			width: 60px;
+			border: 0;
 		}
 		p.wp-embed-heading {
 			margin: 0;
@@ -129,14 +131,13 @@ if ( ! headers_sent() ) {
 </head>
 <body <?php body_class(); ?>>
 	<div <?php post_class( 'wp-embed' ); ?>>
-		<div class="wp-embed-featured-image rectangular">
-			<a href="<?php the_permalink(); ?>" target="_top">
-				<?php echo Template::get_plugin_icon( $post, 'html' ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
-			</a>
-		</div>
-
 		<p class="wp-embed-heading">
 			<a href="<?php the_permalink(); ?>" target="_top">
+				<?php
+					$plugin_icon = Template::get_plugin_icon( $post, 'html' );
+					$plugin_icon = str_replace( $plugin_icon, "class='plugin-icon'", "class='wp-embed-featured-image rectangular plugin-icon'" );
+					echo $plugin_icon;
+				?>
 				<?php the_title(); ?>
 			</a>
 			<span class="byline"><?php the_author_byline(); ?></span>
@@ -170,7 +171,7 @@ if ( ! headers_sent() ) {
 			if ( $tested_up_to ) :
 				?>
 				<span class="tested-with">
-					<i class="dashicons dashicons-wordpress-alt"></i>
+					<i class="dashicons dashicons-wordpress-alt" aria-hidden="true"></i>
 					<?php
 					/* translators: WordPress version. */
 					printf( esc_html__( 'Tested with %s', 'wporg-plugins' ), esc_html( $tested_up_to ) );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/plugin.php
@@ -17,8 +17,9 @@ $tested_up_to = (string) get_post_meta( $post->ID, 'tested', true );
 	<div class="entry-thumbnail">
 		<a href="<?php the_permalink(); ?>" rel="bookmark">
 			<?php
-			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-			echo Template::get_plugin_icon( get_post(), 'html' );
+			$plugin_icon = Template::get_plugin_icon( get_post(), 'html' );
+			$plugin_icon = str_replace( $plugin_icon, "alt=''", "alt='" . get_the_title() . "'" );
+			echo $plugin_icon;
 			?>
 		</a>
 	</div><div class="entry">
@@ -35,15 +36,15 @@ $tested_up_to = (string) get_post_meta( $post->ID, 'tested', true );
 	<hr>
 	<footer>
 		<span class="plugin-author">
-			<i class="dashicons dashicons-admin-users"></i> <?php echo esc_html( strip_tags( get_post_meta( get_the_ID(), 'header_author', true ) ) ?: get_the_author() ); ?>
+			<i class="dashicons dashicons-admin-users" aria-hidden="true"></i> <?php echo esc_html( strip_tags( get_post_meta( get_the_ID(), 'header_author', true ) ) ?: get_the_author() ); ?>
 		</span>
 		<span class="active-installs">
-			<i class="dashicons dashicons-chart-area"></i>
+			<i class="dashicons dashicons-chart-area" aria-hidden="true"></i>
 			<?php echo esc_html( Template::active_installs() ); ?>
 		</span>
 		<?php if ( $tested_up_to ) : ?>
 			<span class="tested-with">
-				<i class="dashicons dashicons-wordpress-alt"></i>
+				<i class="dashicons dashicons-wordpress-alt" aria-hidden="true"></i>
 				<?php
 				/* translators: WordPress version. */
 				printf( esc_html__( 'Tested with %s', 'wporg-plugins' ), esc_html( $tested_up_to ) );
@@ -51,7 +52,7 @@ $tested_up_to = (string) get_post_meta( $post->ID, 'tested', true );
 			</span>
 		<?php endif; ?>
 		<span class="last-updated">
-			<i class="dashicons dashicons-calendar"></i>
+			<i class="dashicons dashicons-calendar" aria-hidden="true"></i>
 			<?php
 			/* Translators: Plugin modified time. */
 			printf( esc_html__( 'Updated %s ago', 'wporg-plugins' ), esc_html( human_time_diff( get_post_modified_time() ) ) );

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/plugin.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/template-parts/plugin.php
@@ -19,7 +19,7 @@ $tested_up_to = (string) get_post_meta( $post->ID, 'tested', true );
 			<?php
 			$plugin_icon = Template::get_plugin_icon( get_post(), 'html' );
 			$plugin_icon = str_replace( $plugin_icon, "alt=''", "alt='" . get_the_title() . "'" );
-			echo $plugin_icon;
+			echo $plugin_icon; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 			?>
 		</a>
 	</div><div class="entry">

--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/embed-repopackage.php
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/embed-repopackage.php
@@ -32,14 +32,11 @@ the_post();
 $theme = wporg_themes_theme_information( $post->post_name );
 ?>
 <div <?php post_class( 'wp-embed' ); ?>>
-	<div class="wp-embed-featured-image rectangular">
-		<a href="<?php the_permalink(); ?>" target="_top">
-			<img src='<?php echo $theme->screenshot_url; ?>'>
-		</a>
-	</div>
-
 	<p class="wp-embed-heading">
 		<a href="<?php the_permalink(); ?>" target="_top">
+			<div class="wp-embed-featured-image rectangular">
+				<img src='<?php echo $theme->screenshot_url; ?>' alt=''>
+			</div>
 			<?php echo esc_html( $theme->name ); ?>
 		</a>
 	</p>


### PR DESCRIPTION
1. Adds empty `alt` attributes to the `get_plugin_icon()` function.
2. Uses the plugin name as alt text on Plugins Directory page.
3. Moves the plugin icon inside the link with visible text for embeds, and adjusts CSS.
4. Hides dashicons from screen readers, both on Plugins Directory page and in plugin embeds.
5. Moves theme's thumbnail image inside the link with visible text for embeds, and adds an empty `alt` attribute.